### PR TITLE
working v2 build with refactor and strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Testing
 tests
 oldTests
+test*
 
 # Logs
 logs

--- a/module/genericsUtils.js
+++ b/module/genericsUtils.js
@@ -1,121 +1,100 @@
 const axios = require('axios');
 const { v4: uuidv4 } = require('uuid');
 
+let endpoint = 'https://api.banana.dev/'
 if ("BANANA_URL" in process.env){
-    var endpoint = process.env.BANANA_URL
+    endpoint = process.env.BANANA_URL
     console.log("Running from", endpoint)
     if (process.env.BANANA_URL === "local"){
         // console.log("Running from local")
         endpoint = "http://localhost/"
     }
-} else {
-    var endpoint = 'https://api.banana.dev/'
 }
 
-exports.runMain = async (apiKey, modelKey, modelParameters) => {
-    const taskID = await callStartAPI(apiKey, modelKey, modelParameters)
-    var retries = 0
+
+exports.runMain = async (apiKey, modelKey, modelInputs, strategy) => {
+    const callID = await startAPI(apiKey, modelKey, modelInputs, strategy)
     while (true) {
-        const jsonOut = await callCheckAPI(taskID).catch(err => {
-            if (err.includes("busy or not available")){
-                retries = retries + 1
-                if (retries > 5){
-                    throw "job check endpoint busy or not available."
-                }
-            } else {
-                throw err
-            }
-        })
+        const jsonOut = await checkAPI(apiKey, callID)
         if (jsonOut !== undefined){
-            if (jsonOut.taskStatus === "Done"){
-                payloadOut = jsonOut.taskOut
-                // Some servers return an "output" keyword so that it can be non-json datatype
-                if('output' in payloadOut){
-                    // console.log("workaround")
-                    return payloadOut.output
-                }
-                return jsonOut.taskOut
+            if (jsonOut.message.toLowerCase() === "success"){
+                return jsonOut
             }
         }
     }
 
 }
 
-exports.startMain = async (apiKey, modelKey, modelParameters) => {
-    const taskID = await callStartAPI(apiKey, modelKey, modelParameters)
-    return taskID
+exports.startMain = async (apiKey, modelKey, modelInputs, strategy) => {
+    const callID = await startAPI(apiKey, modelKey, modelInputs, strategy)
+    return callID
 }
 
-exports.checkMain = async (apiKey, taskID) => {
-    const jsonOut = await callCheckAPI(taskID)
+exports.checkMain = async (apiKey, callID) => {
+    const jsonOut = await checkAPI(apiKey, callID)
     return jsonOut
 }
 
-const callStartAPI = async (apiKey, modelKey, modelParameters) => {
-    const urlStart = endpoint.concat("api/task/start/v1/")
+const startAPI = async (apiKey, modelKey, modelInputs, strategy) => {
+    const urlStart = endpoint.concat("start/v2/")
     const payload = {
         "id": uuidv4(),
         "created": Math.floor(new Date().getTime() / 1000),
-        "data":
-        {
-            "apiKey" : apiKey,
-            "modelKey" : modelKey,
-            "modelParameters" : modelParameters
-        }
+        "apiKey" : apiKey,
+        "modelKey" : modelKey,
+        "modelInputs" : modelInputs,
+        "strategy" : strategy
     }
     
     const response = await axios.post(urlStart, payload).catch(err => {
         if (err.response) {
-            throw `inference start call returned status code ${err.response.status}`
+            throw `server error: status code ${err.response.status}`
         } else if (err.request) {
-            throw 'job start endpoint busy or not available.'
+            throw 'server error: endpoint busy or not available.'
         } else {
             console.log(err)
-            throw "Misc axios error. Please email erik@banana.dev with above error json"
+            throw "Misc axios error. Please email erik@banana.dev with above error"
         }
     })
     const jsonOut = response.data
     
-    if (!jsonOut.success){
-        throw `inference start call failed with message: ${jsonOut.message}`
+    if (jsonOut.message.toLowerCase().includes("error")){
+        throw jsonOut.message
     }
 
-    const taskID = jsonOut.data.taskID
-    if (taskID === undefined){
-        throw  `inference start call failed without a message or taskID`
+    const callID = jsonOut.callID
+    if (callID === undefined){
+        throw  `server error: start call failed without a message or callID`
     }
 
-    return taskID
+    return callID
 }
 
-const callCheckAPI = async (taskID) => {
-    const urlCheck = endpoint.concat("api/task/check/v1/")
+const checkAPI = async (apiKey, callID) => {
+    const urlCheck = endpoint.concat("check/v2/")
 
     const payload = {
         "id": uuidv4(),
         "created": Math.floor(new Date().getTime() / 1000),
         "longPoll": true,
-        "data":
-        {
-            "taskID" : taskID
-        }
+        "apiKey" : apiKey,
+         "callID" : callID
     }
     
     const response = await axios.post(urlCheck, payload).catch(err => {
         if (err.response) {
-            throw `inference check call returned status code ${format.code}`
+            throw `server error: status code ${err.response.status}`
         } else if (err.request) {
-            throw 'server error: Job check endpoint busy or not available.'
+            throw 'server error: endpoint busy or not available.'
         } else {
             console.log(err)
-            throw "Misc axios error. Please email erik@banana.dev with above error json"
+            throw "Misc axios error. Please email erik@banana.dev with above error"
         }
     })
     const jsonOut = response.data
-
-    if (!jsonOut.success){
-        throw `inference check call failed with message: ${jsonOut.message}`
+    
+    if (jsonOut.message.toLowerCase().includes("error")){
+        throw jsonOut.message
     }
-    const data = jsonOut.data
-    return data
+    return jsonOut
 }

--- a/module/index.js
+++ b/module/index.js
@@ -1,23 +1,25 @@
 const genericsUtils = require("./genericsUtils")
 
 // Generics (calling models by modelKey argument rather than by function name)
-exports.run = async (apiKey, modelKey, modelParameters) => {
+exports.run = async (apiKey, modelKey, modelInputs = {}, strategy = {}) => {
   const out = await genericsUtils.runMain(
     apiKey = apiKey, 
     modelKey = modelKey,
-    modelParameters=modelParameters)
+    modelInputs=modelInputs,
+    strategy = strategy)
   return out
 }
 
-exports.start = async (apiKey, modelKey, modelParameters) => {
-  const taskID = await genericsUtils.startMain(
+exports.start = async (apiKey, modelKey, modelInputs = {}, strategy= {}) => {
+  const callID = await genericsUtils.startMain(
     apiKey = apiKey, 
     modelKey = modelKey,
-    modelParameters=modelParameters)
-  return taskID
+    modelInputs=modelInputs,
+    strategy = strategy)
+  return callID
 }
 
-exports.check = async (apiKey, taskID) => {
-  const jsonOut = await genericsUtils.checkMain(apiKey, taskID)
+exports.check = async (apiKey, callID) => {
+  const jsonOut = await genericsUtils.checkMain(apiKey, callID)
   return jsonOut
 }

--- a/module/package.json
+++ b/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@banana-dev/banana-dev",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A node client to interact with Banana's machine learning inference APIs",
   "main": "index.js",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,5 +2,184 @@
   "name": "client-nodejs",
   "lockfileVersion": 2,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "dependencies": {
+        "@banana-dev/banana-dev": "file:module"
+      }
+    },
+    "module": {
+      "version": "1.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "axios": "^0.21.0",
+        "image-to-base64": "^2.1.1",
+        "utf8": "^3.0.0",
+        "uuid": "^8.3.2",
+        "valid-url": "^1.0.9"
+      }
+    },
+    "node_modules/@banana-dev/banana-dev": {
+      "resolved": "module",
+      "link": true
+    },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/image-to-base64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/image-to-base64/-/image-to-base64-2.2.0.tgz",
+      "integrity": "sha512-Z+aMwm/91UOQqHhrz7Upre2ytKhWejZlWV/JxUTD1sT7GWWKFDJUEV5scVQKnkzSgPHFuQBUEWcanO+ma0PSVw==",
+      "dependencies": {
+        "node-fetch": "^2.6.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@banana-dev/banana-dev": {
+      "version": "file:module",
+      "requires": {
+        "axios": "^0.21.0",
+        "image-to-base64": "^2.1.1",
+        "utf8": "^3.0.0",
+        "uuid": "^8.3.2",
+        "valid-url": "^1.0.9"
+      }
+    },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+    },
+    "image-to-base64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/image-to-base64/-/image-to-base64-2.2.0.tgz",
+      "integrity": "sha512-Z+aMwm/91UOQqHhrz7Upre2ytKhWejZlWV/JxUTD1sT7GWWKFDJUEV5scVQKnkzSgPHFuQBUEWcanO+ma0PSVw==",
+      "requires": {
+        "node-fetch": "^2.6.0"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,1 +1,5 @@
-{}
+{
+  "dependencies": {
+    "@banana-dev/banana-dev": "file:module"
+  }
+}


### PR DESCRIPTION
# This is our first major breaking change

# Why:
- We needed to add a strategy argument, to allow batchSize parallelization across many inference servers. As part of this, we needed to be able to return a list of outputs rather than a single output, breaking backwards compatibility 
- We needed compatibility to the new "pull" style inference servers we've implemented on the backend
- Our outputs were getting pretty frankensteiny across a wide range of use cases, so we're following a standard format without any tricky client parsing logic

# Testing:
Tests pass end to end for:
- New "pull" style inference servers
- Legacy "push" style inference servers

We tried our best to make all models still work through this new sdk. The API itself is a breaking change out of necessity, but if your inference call are breaking, please contact us.